### PR TITLE
Add logger.GetLevel()

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -15,6 +15,7 @@ type Logger interface {
 	Error(message string, args ...interface{})
 	LogIfError(err error, args ...interface{})
 	SetLevel(logLevel LogLevel)
+	GetLevel() LogLevel
 	IsInterfaceNil() bool
 }
 

--- a/logSubsystem.go
+++ b/logSubsystem.go
@@ -73,6 +73,20 @@ func GetLogLevelPattern() string {
 	return logPattern
 }
 
+// GetLoggerLogLevel gets the log level of the specified logger
+func GetLoggerLogLevel(loggerName string) LogLevel {
+	logMut.RLock()
+	defer logMut.RUnlock()
+
+	loggerFromMap, ok := loggers[loggerName]
+	if !ok {
+		return LogNone
+	}
+
+	logLevel := loggerFromMap.GetLevel()
+	return logLevel
+}
+
 // ToggleLoggerName enables / disables logger name
 func ToggleLoggerName(enable bool) {
 	logMut.Lock()

--- a/logSubsystem.go
+++ b/logSubsystem.go
@@ -18,16 +18,12 @@ var mutDisplayByteSlice = &sync.RWMutex{}
 var displayByteSlice func(slice []byte) string
 
 func init() {
-	logMut.Lock()
 	logPattern = "*:INFO"
 	loggers = make(map[string]*logger)
 	defaultLogOut = &logOutputSubject{}
 	_ = defaultLogOut.AddObserver(os.Stdout, &ConsoleFormatter{})
-	logMut.Unlock()
 
-	mutDisplayByteSlice.Lock()
 	displayByteSlice = ToHex
-	mutDisplayByteSlice.Unlock()
 }
 
 // GetOrCreate returns a log based on the name provided, generating a new log if there is no log with provided name

--- a/logSubsystem_test.go
+++ b/logSubsystem_test.go
@@ -79,6 +79,7 @@ func TestGetLoggerLogLevel(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, logger.LogInfo, logger.GetLoggerLogLevel("1"))
 	assert.Equal(t, logger.LogTrace, logger.GetLoggerLogLevel("2"))
+	assert.Equal(t, logger.LogNone, logger.GetLoggerLogLevel("42"))
 
 	// rollback to the default value
 	_ = logger.SetLogLevel("*:INFO")

--- a/logSubsystem_test.go
+++ b/logSubsystem_test.go
@@ -36,7 +36,7 @@ func TestSetLogLevel_NonWildcardPatternShouldNotError(t *testing.T) {
 	assert.Equal(t, logger.LogTrace, log1.LogLevel())
 	assert.Equal(t, logger.LogTrace, log2.LogLevel())
 
-	//rollback to the default value
+	// rollback to the default value
 	_ = logger.SetLogLevel("*:INFO")
 }
 
@@ -51,7 +51,7 @@ func TestSetLogLevel_WildcardPatternShouldWork(t *testing.T) {
 	assert.Equal(t, logger.LogDebug, log2.LogLevel())
 	assert.Equal(t, logger.LogDebug, *logger.DefaultLogLevel)
 
-	//rollback to the default value
+	// rollback to the default value
 	_ = logger.SetLogLevel("*:INFO")
 }
 
@@ -66,6 +66,20 @@ func TestSetLogLevel_MultipleVariantsShouldWork(t *testing.T) {
 	assert.Equal(t, logger.LogError, log2.LogLevel())
 	assert.Equal(t, logger.LogTrace, *logger.DefaultLogLevel)
 
-	//rollback to the default value
+	// rollback to the default value
+	_ = logger.SetLogLevel("*:INFO")
+}
+
+func TestGetLoggerLogLevel(t *testing.T) {
+	_ = logger.GetOrCreate("1")
+	_ = logger.GetOrCreate("2")
+
+	err := logger.SetLogLevel("1:INFO,2:TRACE")
+
+	assert.Nil(t, err)
+	assert.Equal(t, logger.LogInfo, logger.GetLoggerLogLevel("1"))
+	assert.Equal(t, logger.LogTrace, logger.GetLoggerLogLevel("2"))
+
+	// rollback to the default value
 	_ = logger.SetLogLevel("*:INFO")
 }

--- a/logger.go
+++ b/logger.go
@@ -90,6 +90,14 @@ func (l *logger) SetLevel(logLevel LogLevel) {
 	l.mutLevel.Unlock()
 }
 
+// GetLevel gets the current level of the logger
+func (l *logger) GetLevel() LogLevel {
+	l.mutLevel.RLock()
+	level := l.logLevel
+	l.mutLevel.RUnlock()
+	return level
+}
+
 // IsInterfaceNil returns true if there is no value under the interface
 func (l *logger) IsInterfaceNil() bool {
 	return l == nil


### PR DESCRIPTION
Required to fetch and forward the current log level of a logger to a component out-of-process (Arwen). We might change this when adding pipe loggers in the repository, but until then, this function is needed.

Also simplified `init()` function (removed critical sections) with respect to:
 - https://golang.org/ref/mem#tmp_4
 - https://stackoverflow.com/questions/24790175/when-is-the-init-function-run