### PR TITLE
Fixed initial log size

### DIFF
--- a/file/fileLogging.go
+++ b/file/fileLogging.go
@@ -63,7 +63,7 @@ func NewFileLogging(args ArgsFileLogging) (*fileLogging, error) {
 		defaultLogsPath: args.DefaultLogsPath,
 		logFilePrefix:   args.LogFilePrefix,
 		isClosed:        false,
-		lifeSpanSize:    defaultFileSizeInMB,
+		lifeSpanSize:    defaultFileSizeInMB * oneMegaByte,
 		notifyChan:      make(chan struct{}),
 	}
 

--- a/file/fileLogging_test.go
+++ b/file/fileLogging_test.go
@@ -33,6 +33,8 @@ func TestNewFileLogging(t *testing.T) {
 
 		assert.False(t, check.IfNil(fl))
 		assert.Nil(t, err)
+		defaultSize := 1024 * 1024 * 1024 // 1GB
+		assert.Equal(t, defaultSize, int(fl.lifeSpanSize))
 		_ = fl.Close()
 	})
 }


### PR DESCRIPTION
- fixed initial log size from 1024 bytes to 1GB